### PR TITLE
Remove dead url from image_placeholder_services

### DIFF
--- a/faker/providers/internet/__init__.py
+++ b/faker/providers/internet/__init__.py
@@ -111,8 +111,6 @@ class Provider(BaseProvider):
         '{{url}}{{uri_path}}/{{uri_page}}{{uri_extension}}',
     )
     image_placeholder_services = (
-        'https://placeholdit.imgix.net/~text'
-        '?txtsize=55&txt={width}x{height}&w={width}&h={height}',
         'https://www.lorempixel.com/{width}/{height}',
         'https://dummyimage.com/{width}x{height}',
         'https://placekitten.com/{width}/{height}',


### PR DESCRIPTION
Looks like placeholdit.imgix.net is no longer working, so remove it from code.

### What does this changes

Remove dead image stubs service from code.

### What was wrong

placeholdit.imgix.net does not work anymore

